### PR TITLE
Fix module init

### DIFF
--- a/hello_module/hello.c
+++ b/hello_module/hello.c
@@ -36,15 +36,23 @@ static char hello_docstring[] = "Hello world module for Python written in C";
  */
 static PyMethodDef module_methods[] = {
     {"hello", (PyCFunction) hello, METH_NOARGS, hello_docstring},
-    {NULL, NULL, 0, NULL}
+    {NULL}
 };
 
+static struct PyModuleDef module =
+{
+    PyModuleDef_HEAD_INIT,
+    "module",
+    "usage: module.create()\n",
+    -1,   /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+    module_methods
+};
 
 /**
  * Module inicialization function
  */
 PyMODINIT_FUNC
-initmodule(void)
+PyInit_module(void)
 {
-    Py_InitModule("module", module_methods);
+    return PyModule_Create(&module);
 }


### PR DESCRIPTION
The current code was causing this error:

```
fcsv.c:34:1: warning: return type defaults to ‘int’ [-Wimplicit
-int]
 PyInit_fcsv(void) ^~~~~~~~~~~
In file included from /usr/include/python3.6m/Python.h:117,
                 from fcsv.c:1:
fcsv.c: In function ‘PyInit_fcsv’:fcsv.c:36:28: warning: passing argument 1 of ‘PyModule_Create2’
 from incompatible pointer type [-Wincompatible-pointer-types]     return PyModule_Create(&fcsv_methods);
                            ^~~~~~~~~~~~~
```

Adapted to Python 3. The solution was copied from https://stackoverflow.com/questions/43621948/c-python-module-import-error-undefined-symbol-py-initmodule3-py-initmodu. :P